### PR TITLE
feat(describers): afterEach

### DIFF
--- a/packages/e2e/globals.js
+++ b/packages/e2e/globals.js
@@ -2,5 +2,8 @@ const describers = require('describers');
 const expect = require('expect');
 module.exports = {
   expect,
-  ...describers
+  it: describers.it,
+  describe: describers.describe,
+  beforeEach: describers.beforeEach,
+  afterEach: describers.afterEach,
 };

--- a/packages/e2e/index.js
+++ b/packages/e2e/index.js
@@ -4,7 +4,7 @@ const {formatExecError} = require('jest-message-util');
 const {ScriptTransformer} = require('@jest/transform');
 const globals = require('./globals');
 const playwright = require('playwright');
-const {describe} = require('describers');
+const {createSuite} = require('describers');
 /** @typedef {import('describers').Test} Test */
 
 class PlaywrightRunnerE2E {
@@ -34,12 +34,12 @@ class PlaywrightRunnerE2E {
     const suiteToTests = new Map();
     const startedSuites = new Set();
     const resultsForSuite = new Map();
-    const rootSuite = describe(async () => {
+    const rootSuite = createSuite(async () => {
       for (const testSuite of testSuites) {
         const transformer = new ScriptTransformer(testSuite.context.config);
         resultsForSuite.set(testSuite, []);
         suiteToTests.set(testSuite, new Set());
-        const suite = describe(async () => {
+        const suite = createSuite(async () => {
           transformer.requireAndTranspileModule(testSuite.path);
         });
         for (const test of await suite.tests()) {
@@ -105,7 +105,7 @@ class PlaywrightRunnerE2E {
 function purgeRequireCache(files) {
   const blackList = new Set(files);
   for (const filePath of Object.keys(require.cache)) {
-    /** @type {NodeModule|null} */
+    /** @type {NodeModule|null|undefined} */
     let module = require.cache[filePath];
     while (module) {
       if (blackList.has(module.filename)) {

--- a/packages/e2e/tests/assets/oneTest.js
+++ b/packages/e2e/tests/assets/oneTest.js
@@ -1,3 +1,7 @@
-it('is one test', function(){
+beforeEach(state => {
+  state.before = true;
+});
 
+it('is one test', state => {
+  expect(state.before).toEqual(true);
 });

--- a/packages/e2e/tests/assets/twoTests.js
+++ b/packages/e2e/tests/assets/twoTests.js
@@ -1,6 +1,15 @@
-it('is the first test', function(){
-
+beforeEach(state => {
+  state.counter = (state.counter || 0) + 1;
 });
-it('is the second test', function(){
 
+afterEach(state => {
+  state.counter++;
+});
+
+it('is the first test', state => {
+  expect(state.counter).toEqual(1);
+});
+
+it('is the second test', state => {
+  expect(state.counter).toEqual(1);
 });

--- a/packages/unit/web/root.html
+++ b/packages/unit/web/root.html
@@ -10,16 +10,18 @@
     <script type="module">
       import * as describers from 'https://third_party/?name=describers';
       import expect from 'https://third_party/?name=expect';
-      
+
       // We don't need to tell people to download React DevTools every test.
       if (!window.__REACT_DEVTOOLS_GLOBAL_HOOK__)
         window.__REACT_DEVTOOLS_GLOBAL_HOOK__= { isDisabled: true };
 
-      for (const name in describers)
-        window[name] = describers[name];
+      window.it = describers.it;
+      window.describe = describers.describe;
+      window.beforeEach = describers.beforeEach;
+      window.afterEach = describers.afterEach;
       window.expect = expect;
       let finishedGatheringTests;
-      const rootSuite = describers.describe(() => new Promise(x => finishedGatheringTests = x));
+      const rootSuite = describers.createSuite(() => new Promise(x => finishedGatheringTests = x));
       const testsPromise = rootSuite.tests();
       window.__playwright__runAllTests = async function() {
         finishedGatheringTests();


### PR DESCRIPTION
Drive-by: stop leaking Suite and Test instances to the test script, use `createSuite` and `createTest` internally.