### PR TITLE
Add missing link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ it('loads pages without css requests', async ({ mockedContext }) => {
 });
 ```
 
+[browser-context]: https://playwright.dev/#path=docs%2Fapi.md&q=class-browsercontext
 [browser-opts]: https://playwright.dev/#path=docs%2Fapi.md&q=browsertypelaunchoptions
 [context-opts]: https://playwright.dev/#path=docs%2Fapi.md&q=browsernewcontextoptions
 [multi-page]: https://playwright.dev/#path=docs%2Fmulti-pages.md&q=


### PR DESCRIPTION
Without this, the links using this target were rendered like this:

`[BrowserContext][browser-context]`