### PR TITLE
Fixed examples

### DIFF
--- a/examples/basic-js/package.json
+++ b/examples/basic-js/package.json
@@ -8,7 +8,7 @@
     "@playwright/test": "0.9.13"
   },
   "scripts": {
-    "test": "npx folio"
+    "test": "folio"
   },
   "keywords": [],
   "author": {

--- a/examples/basic-js/package.json
+++ b/examples/basic-js/package.json
@@ -8,7 +8,7 @@
     "@playwright/test": "0.9.13"
   },
   "scripts": {
-    "test": "test-runner"
+    "test": "npx folio"
   },
   "keywords": [],
   "author": {

--- a/examples/basic-ts/package.json
+++ b/examples/basic-ts/package.json
@@ -9,7 +9,7 @@
     "@playwright/test": "0.9.13"
   },
   "scripts": {
-    "test": "npx folio"
+    "test": "folio"
   },
   "keywords": [],
   "author": {

--- a/examples/basic-ts/package.json
+++ b/examples/basic-ts/package.json
@@ -9,7 +9,7 @@
     "@playwright/test": "0.9.13"
   },
   "scripts": {
-    "test": "test-runner"
+    "test": "npx folio"
   },
   "keywords": [],
   "author": {

--- a/examples/login-once-per-worker/package.json
+++ b/examples/login-once-per-worker/package.json
@@ -9,7 +9,7 @@
     "@playwright/test": "0.151.0"
   },
   "scripts": {
-    "test": "npx folio"
+    "test": "folio"
   },
   "keywords": [],
   "author": {

--- a/examples/login-once-per-worker/package.json
+++ b/examples/login-once-per-worker/package.json
@@ -9,7 +9,7 @@
     "@playwright/test": "0.151.0"
   },
   "scripts": {
-    "test": "test-runner"
+    "test": "npx folio"
   },
   "keywords": [],
   "author": {

--- a/examples/screenshot-on-failure/package.json
+++ b/examples/screenshot-on-failure/package.json
@@ -8,7 +8,7 @@
     "@playwright/test": "0.9.13"
   },
   "scripts": {
-    "test": "npx folio"
+    "test": "folio"
   },
   "keywords": [],
   "author": {

--- a/examples/screenshot-on-failure/package.json
+++ b/examples/screenshot-on-failure/package.json
@@ -8,7 +8,7 @@
     "@playwright/test": "0.9.13"
   },
   "scripts": {
-    "test": "test-runner"
+    "test": "npx folio"
   },
   "keywords": [],
   "author": {


### PR DESCRIPTION
The examples have and old reference to the test-runner for running the tests. Updated the package.json files to call `npx folio`