### PR TITLE
feat: add cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@ Cross-browser end-to-end testing for web apps. Browser automation with [Playwrig
 Playwright test runner is **available in preview** and minor breaking changes could happen. We welcome your feedback to shape this towards 1.0.
 
 - [Get started](#get-started)
-  - [Installation](#installation)
-  - [Write a test](#write-a-test)
-  - [Write a configuration file](#write-a-configuration-file)
-  - [Run the test](#run-the-test)
+  - [Writing a test](#writing-a-test)
+  - [Writing a configuration file](#writing-a-configuration-file)
+  - [Running tests](#running-tests)
 - [Examples](#examples)
   - [Multiple pages](#multiple-pages)
   - [Mobile emulation](#mobile-emulation)
@@ -22,13 +21,30 @@ Playwright test runner is **available in preview** and minor breaking changes co
 
 ## Get started
 
-### Installation
+- Install `@playwright/test`:
+  ```sh
+  $ npm i -D @playwright/test
+  ```
 
-```sh
-npm i -D @playwright/test
-```
+- Create `tests/` directory with the default configuration and example test:
+  ```sh
+  $ npx playwright-test example-js tests/
+  ```
+  Alternatively, for TypeScript:
+  ```sh
+  $ npx playwright-test example-ts tests/
+  ```
 
-### Write a test
+- Run tests
+  ```sh
+  $ npx folio --config=tests/config.js
+  ```
+  Alternatively, for TypeScript:
+  ```sh
+  $ npx folio --config=tests/config.ts
+  ```
+
+### Writing a test
 
 Create `foo.spec.ts` to define your test. The test function uses the [`page`][page] argument for browser automation.
 
@@ -49,7 +65,7 @@ The test runner provides browser primitives as arguments to your test functions.
 - `browser`: Instance of [Browser][browser]. Browsers are shared across tests to optimize resources. Learn [how to configure](#modify-options) browser launch.
 - `browserName`: The name of the browser currently running the test. Either `chromium`, `firefox` or `webkit`.
 
-### Write a configuration file
+### Writing a configuration file
 
 Create `config.ts` to configure your tests. Here is an example configuration that runs every test in Chromium, Firefox and WebKit.
 
@@ -72,9 +88,9 @@ test.runWith(new FirefoxEnv(options), { tag: 'firefox' });
 test.runWith(new WebKitEnv(options), { tag: 'webkit' });
 ```
 
-### Run the test
+### Running tests
 
-Tests can be run in single or multiple browsers, in parallel or sequentially.
+Tests can be run in a single or multiple browsers, in parallel or sequentially.
 
 ```sh
 # Run all tests across Chromium, Firefox and WebKit

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require('./out/cli');

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   "repository": "github:Microsoft/playwright-test",
   "description": "A test runner for running tests with Playwright.",
   "main": "out/index.js",
+  "bin": {
+    "playwright-test": "./cli.js"
+  },
   "dependencies": {
     "folio": "=0.3.22-alpha",
     "playwright": "=1.10.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as path from 'path';
+import * as fs from 'fs';
+import { project as tsProject } from './tsProject';
+import { project as jsProject } from './jsProject';
+
+if (process.argv.length < 3 || !['example', 'example-js', 'example-ts'].includes(process.argv[2])) {
+  console.error(`Usage:`);
+  console.error(`npx playwright-test example <test-directory>`);
+  console.error(`npx playwright-test example-ts <test-directory>`);
+  process.exit(1);
+}
+
+const testDir = path.resolve(process.cwd(), process.argv[3]);
+if (fs.existsSync(testDir) && fs.readdirSync(testDir).length) {
+  console.error(`ERROR: ${testDir} is not empty`);
+  process.exit(1);
+}
+
+console.log(`Creating test example in ${testDir}`);
+const project = process.argv[2] === 'example-ts' ? tsProject : jsProject;
+for (const [filePath, content] of Object.entries(project.files)) {
+  const platformPath = path.join(...filePath.split('/'));
+  console.log(`  - writing ${platformPath}`);
+  const fullPath = path.join(testDir, platformPath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content, 'utf-8');
+}
+console.log('');
+console.log(`Run tests:`);
+console.log(`  npx folio --config=${path.join(process.argv[3], project.configFile)}`);
+console.log('');
+console.log(`Get help:`);
+console.log(`  npx folio --help`);
+process.exit(0);

--- a/src/jsProject.ts
+++ b/src/jsProject.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const kConfigFile = `const { ChromiumEnv, FirefoxEnv, WebKitEnv, test, setConfig } = require('@playwright/test');
+
+// Global configuration.
+setConfig({
+  testDir: __dirname,
+  timeout: 30000,
+});
+
+// Playwright options for browser environments.
+const options = {
+  headless: true,
+  viewport: { width: 1280, height: 720 },
+};
+
+// Run tests in three browsers.
+test.runWith(new ChromiumEnv(options), { tag: 'chromium' });
+test.runWith(new FirefoxEnv(options), { tag: 'firefox' });
+test.runWith(new WebKitEnv(options), { tag: 'webkit' });
+`;
+
+const kTestFile = `const { test, expect } = require('@playwright/test');
+
+test('check page title', async ({ page }) => {
+  await page.setContent('<title>My Page</title><body>Hello</body>');
+  expect(await page.title()).toBe('My Page');
+});
+`;
+
+export const project = {
+  configFile: 'config.js',
+  files: {
+    'config.js': kConfigFile,
+    'title.spec.js': kTestFile,
+  },
+};

--- a/src/tsProject.ts
+++ b/src/tsProject.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const kConfigFile = `import { ChromiumEnv, FirefoxEnv, WebKitEnv, PlaywrightOptions, test, setConfig } from '@playwright/test';
+
+// Global configuration.
+setConfig({
+  // Search for tests.
+  testDir: __dirname,
+  timeout: 30000,
+});
+
+// Playwright options for browser environments.
+const options: PlaywrightOptions = {
+  headless: true,
+  viewport: { width: 1280, height: 720 },
+};
+
+// Run tests in three browsers.
+test.runWith(new ChromiumEnv(options), { tag: 'chromium' });
+test.runWith(new FirefoxEnv(options), { tag: 'firefox' });
+test.runWith(new WebKitEnv(options), { tag: 'webkit' });
+`;
+
+const kTestFile = `import { test, expect } from '@playwright/test';
+
+test('check page title', async ({ page }) => {
+  await page.setContent('<title>My Page</title><body>Hello</body>');
+  expect(await page.title()).toBe('My Page');
+});
+`;
+
+export const project = {
+  configFile: 'config.ts',
+  files: {
+    'config.ts': kConfigFile,
+    'title.spec.ts': kTestFile,
+  },
+};


### PR DESCRIPTION
Currently supports `npx playwright-test [example-js|example-ts] <test-dir>`.