### PR TITLE
Updated 'snapshotPathSegment' logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,9 @@ export class PlaywrightEnv implements folio.Env<PlaywrightTestArgs> {
     this._allPages = [];
     this._context.on('page', page => this._allPages.push(page));
     this._page = await this._context.newPage();
-    testInfo.snapshotPathSegment = this._options.snapshotPathSegment || (this._browserName + '-' + process.platform);
+    testInfo.snapshotPathSegment = this._options.snapshotPathSegment === undefined
+      ? (this._browserName + '-' + process.platform)
+      : this._options.snapshotPathSegment;
     return {
       playwright: this._playwright!,
       browserName: this._browserName,


### PR DESCRIPTION
Lines 74-76 show that you can pass `snapshotPathSegment` as empty string to make the snapshots browser agnostic. However, on line 113 it wasn't honoring an empty string since an empty string is falsey. This change checks for undefined instead.